### PR TITLE
Fixed typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Follow these steps:hammer: for contributing:
 
 :tada: Merge the changes in your branch.
 
->git merge upstream/(your_branch_name)
+>git merge upstream/main
 
 :alien: Push your changes to your branch.
 


### PR DESCRIPTION
**Description**
We should fetch and merge `upstream/main` into our local branch and not `upstream/your_branch_name`, which doesn't even exist in the upstream.

![Screenshot (3)](https://user-images.githubusercontent.com/63552235/113733707-58d07d80-9718-11eb-9bde-eea7e02423a8.png)


**Type of Change:**

<!--- **Delete irrelevant options.** --->


- [x] Documentation




**Checklist**

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My changes generate no new warnings
- [x] The title of my pull request is a short description of the requested changes.
