### PR TITLE
Add API endpoint documentation for doubts and doubtAnswers

### DIFF
--- a/src/modules/course/course.module.ts
+++ b/src/modules/course/course.module.ts
@@ -5,6 +5,7 @@ import { CourseController } from './course.controller';
 import { CourseService } from './course.service';
 import { ScheduleSchema } from './schema/schedule.schema';
 import { ReviewSchema } from './schema/review.schema';
+import { DoubtSchema } from 'modules/doubt/schema/doubt.schema';
 
 @Module({
   imports: [
@@ -12,6 +13,7 @@ import { ReviewSchema } from './schema/review.schema';
       { name: 'Course', schema: CourseSchema },
       { name: 'Schedule', schema: ScheduleSchema },
       { name: 'Review', schema: ReviewSchema },
+      { name: 'Doubt', schema: DoubtSchema },
     ]),
   ],
   controllers: [CourseController],

--- a/src/modules/course/course.module.ts
+++ b/src/modules/course/course.module.ts
@@ -6,6 +6,7 @@ import { CourseService } from './course.service';
 import { ScheduleSchema } from './schema/schedule.schema';
 import { ReviewSchema } from './schema/review.schema';
 import { DoubtSchema } from 'modules/doubt/schema/doubt.schema';
+import { DoubtAnswerSchema } from 'modules/doubt/schema/doubtAnswer.schema';
 
 @Module({
   imports: [
@@ -14,6 +15,7 @@ import { DoubtSchema } from 'modules/doubt/schema/doubt.schema';
       { name: 'Schedule', schema: ScheduleSchema },
       { name: 'Review', schema: ReviewSchema },
       { name: 'Doubt', schema: DoubtSchema },
+      { name: 'DoubtAnswer', schema: DoubtAnswerSchema },
     ]),
   ],
   controllers: [CourseController],

--- a/src/modules/course/course.service.spec.ts
+++ b/src/modules/course/course.service.spec.ts
@@ -25,6 +25,10 @@ describe('CourseService', () => {
           provide: getModelToken('Doubt'),
           useValue: {},
         },
+        {
+          provide: getModelToken('DoubtAnswer'),
+          useValue: {},
+        },
       ],
     }).compile();
 

--- a/src/modules/course/course.service.spec.ts
+++ b/src/modules/course/course.service.spec.ts
@@ -21,6 +21,10 @@ describe('CourseService', () => {
           provide: getModelToken('Review'),
           useValue: {},
         },
+        {
+          provide: getModelToken('Doubt'),
+          useValue: {},
+        },
       ],
     }).compile();
 

--- a/src/modules/course/course.service.ts
+++ b/src/modules/course/course.service.ts
@@ -17,6 +17,7 @@ import { CreateReviewDto } from './dto/create-review.dto';
 import { UpdateReviewDto } from './dto/update-review.dto';
 import { Review } from './schema/review.schema';
 import { Doubt } from 'modules/doubt/schema/doubt.schema';
+import { DoubtAnswer } from 'modules/doubt/schema/doubtAnswer.schema';
 
 @Injectable()
 export class CourseService {
@@ -25,6 +26,8 @@ export class CourseService {
     @InjectModel('Schedule') private readonly ScheduleModel: Model<Schedule>,
     @InjectModel('Review') private readonly ReviewModel: Model<Review>,
     @InjectModel('Doubt') private readonly DoubtModel: Model<Doubt>,
+    @InjectModel('DoubtAnswer')
+    private readonly DoubtAnswerModel: Model<DoubtAnswer>,
   ) {}
 
   // fetch all courses
@@ -33,7 +36,14 @@ export class CourseService {
       return await this.CourseModel.find()
         .populate('schedule')
         .populate('reviews')
-        .populate('doubts')
+        .populate({
+          path: 'doubts',
+          model: 'Doubt',
+          populate: {
+            path: 'answers',
+            model: 'DoubtAnswer',
+          },
+        })
         .exec();
     } catch (e) {
       throw new InternalServerErrorException(e);

--- a/src/modules/course/course.service.ts
+++ b/src/modules/course/course.service.ts
@@ -16,6 +16,7 @@ import { UpdateScheduleDto } from './dto/update-schedule.dto';
 import { CreateReviewDto } from './dto/create-review.dto';
 import { UpdateReviewDto } from './dto/update-review.dto';
 import { Review } from './schema/review.schema';
+import { Doubt } from 'modules/doubt/schema/doubt.schema';
 
 @Injectable()
 export class CourseService {
@@ -23,6 +24,7 @@ export class CourseService {
     @InjectModel('Course') private readonly CourseModel: Model<Course>,
     @InjectModel('Schedule') private readonly ScheduleModel: Model<Schedule>,
     @InjectModel('Review') private readonly ReviewModel: Model<Review>,
+    @InjectModel('Doubt') private readonly DoubtModel: Model<Doubt>,
   ) {}
 
   // fetch all courses
@@ -31,6 +33,7 @@ export class CourseService {
       return await this.CourseModel.find()
         .populate('schedule')
         .populate('reviews')
+        .populate('doubts')
         .exec();
     } catch (e) {
       throw new InternalServerErrorException(e);
@@ -43,6 +46,7 @@ export class CourseService {
       const Course = await this.CourseModel.findById(courseId)
         .populate('schedule')
         .populate('reviews')
+        .populate('doubts')
         .exec();
       if (Course) {
         return Course;

--- a/src/modules/course/docUtils/course.responsedoc.ts
+++ b/src/modules/course/docUtils/course.responsedoc.ts
@@ -1,3 +1,4 @@
+import { Doubt } from 'modules/doubt/schema/doubt.schema';
 import { TagType } from '../course-tag.enum';
 import { courseLevelType } from '../courseLevel.enum';
 import { ReviewType } from '../review.enum';
@@ -124,6 +125,12 @@ export default class CourseResponseBody {
    * @example 'https://codeforcause.org/courseTrailer'
    */
   courseTrailerUrl: string;
+
+  /**
+   * The doubts of the course with its answers
+   * @example []
+   */
+  doubts: Doubt[];
 }
 
 export class ScheduleResponseBody {

--- a/src/modules/course/schema/course.schema.ts
+++ b/src/modules/course/schema/course.schema.ts
@@ -4,6 +4,7 @@ import { Schedule } from './schedule.schema';
 import { TagType } from '../course-tag.enum';
 import { Review } from './review.schema';
 import { courseLevelType } from '../courseLevel.enum';
+import { Doubt } from 'modules/doubt/schema/doubt.schema';
 
 export type CourseDocument = Course & Document;
 
@@ -68,6 +69,9 @@ export class Course {
 
   @Prop({ type: [{ type: SchemaTypes.Types.ObjectId, ref: 'Review' }] })
   reviews: Review[];
+
+  @Prop({ type: [{ type: SchemaTypes.Types.ObjectId, ref: 'Doubt' }] })
+  doubts: Doubt[];
 }
 
 export const CourseSchema = SchemaFactory.createForClass(Course);

--- a/src/modules/doubt/docUtils/apidoc.ts
+++ b/src/modules/doubt/docUtils/apidoc.ts
@@ -1,0 +1,45 @@
+import DoubtResponseBody, {
+  DoubtAnswerResponseBody,
+} from './doubt.responsedoc';
+import { ApiResponseOptions } from '@nestjs/swagger';
+
+const addDoubt: ApiResponseOptions = {
+  description: 'Add a doubt',
+  type: DoubtResponseBody,
+};
+
+const updateDoubt: ApiResponseOptions = {
+  description: 'Update a doubt',
+  type: DoubtResponseBody,
+};
+
+const deleteDoubt: ApiResponseOptions = {
+  description: 'Delete a doubt',
+  type: DoubtResponseBody,
+};
+
+const addDoubtAnswer: ApiResponseOptions = {
+  description: 'Add a doubt Answer',
+  type: DoubtAnswerResponseBody,
+};
+
+const updateDoubtAnswer: ApiResponseOptions = {
+  description: 'Update a doubt Answer',
+  type: DoubtAnswerResponseBody,
+};
+
+const deleteDoubtAnswer: ApiResponseOptions = {
+  description: 'Delete a doubt Answer',
+  type: DoubtAnswerResponseBody,
+};
+
+const responses = {
+  addDoubt,
+  updateDoubt,
+  deleteDoubt,
+  addDoubtAnswer,
+  updateDoubtAnswer,
+  deleteDoubtAnswer,
+};
+
+export default responses;

--- a/src/modules/doubt/docUtils/doubt.paramdocs.ts
+++ b/src/modules/doubt/docUtils/doubt.paramdocs.ts
@@ -1,0 +1,22 @@
+import { ApiParamOptions } from '@nestjs/swagger';
+
+export const courseId: ApiParamOptions = {
+  name: 'courseId',
+  type: String,
+  description: 'Course Id in the form of MongoId',
+  example: '60ccf3758dc53371bd4d0154',
+};
+
+export const doubtId: ApiParamOptions = {
+  name: 'doubtId',
+  type: String,
+  description: 'Doubt Id in the form of MongoId',
+  example: '60ccf3758dc53371bd4d0154',
+};
+
+export const doubtAnswerId: ApiParamOptions = {
+  name: 'doubtAnswerId',
+  type: String,
+  description: 'DoubtAnswer Id in the form of MongoId',
+  example: '60ccf3758dc53371bd4d0154',
+};

--- a/src/modules/doubt/docUtils/doubt.responsedoc.ts
+++ b/src/modules/doubt/docUtils/doubt.responsedoc.ts
@@ -1,0 +1,67 @@
+import { TagType } from '../doubt-tag.enum';
+import { DoubtAnswer } from '../schema/doubtAnswer.schema';
+
+export default class DoubtResponseBody {
+  /**
+   * DoubtId
+   * @example 60ccf3037025096f45cb87bf
+   */
+  id: string;
+
+  /**
+   * The name of the person who asked the doubt
+   * @example 'John Doe'
+   */
+  asked_by: string;
+
+  /**
+   * The Answer of the doubt
+   * @example []
+   */
+  answers: DoubtAnswer[];
+
+  /**
+   * Whether the metor's assistance is needed or not for the doubt
+   * @example true
+   */
+  request_mentor: boolean;
+
+  /**
+   * Whether the doubt was resolved or not
+   * @example true
+   */
+  is_resolved: boolean;
+
+  /**
+   * The question/doubt
+   * @example "Why do we use memoization over tabulation ?"
+   */
+  question: string;
+
+  /**
+   * The tags associated with the doubt
+   * @example "Web development"
+   */
+  tags: TagType[];
+}
+
+export class DoubtAnswerResponseBody {
+  /**
+   * DoubtAnswerId
+   * @example 60ccf3037025096f45cb87bf
+   */
+  id: string;
+
+  /**
+   * The name of the person who answered the doubt
+   * @example 'John Doe'
+   */
+  answered_by: string;
+
+  /**
+   * The asnwer to the doubt
+   * @example "We use this to conserve time by applying alogorithm of lesser time complexity"
+   */
+
+  answer: string;
+}

--- a/src/modules/doubt/doubt-tag.enum.ts
+++ b/src/modules/doubt/doubt-tag.enum.ts
@@ -1,0 +1,5 @@
+export enum TagType {
+  WEB_DEV = 'Web Development',
+  AND_DEV = 'Android Dev',
+  AI = 'AI',
+}

--- a/src/modules/doubt/doubt.controller.ts
+++ b/src/modules/doubt/doubt.controller.ts
@@ -1,30 +1,79 @@
-import { Body, Controller, Get, Param, Post } from '@nestjs/common';
-import { ApiCreatedResponse, ApiTags } from '@nestjs/swagger';
+import { Body, Controller, Delete, Param, Post, Put } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { Schema } from 'mongoose';
 import { DoubtService } from './doubt.service';
 import { CreateDoubtDto } from './dto/create-doubt.dto';
+import { CreateDoubtAnswerDto } from './dto/create-doubtAnswer.dto';
+import { UpdateDoubtDto } from './dto/update-doubt.dto';
+import { UpdateDoubtAnswerDto } from './dto/update-doubtAnswer.dto';
 import { DoubtDocument as Doubt } from './schema/doubt.schema';
+import { DoubtAnswer } from './schema/doubtAnswer.schema';
 
 @ApiTags('Doubt')
 @Controller('doubt')
 export class DoubtController {
   constructor(private doubtService: DoubtService) {}
 
-  @Get()
-  async getAllDoubts() {
-    return await this.doubtService.getAllDoubts();
+  // add a new doubt
+  @Post('/new/:courseId')
+  async askNewDoubt(
+    @Param('courseId') courseId: Schema.Types.ObjectId,
+    @Body() createDoubtDto: CreateDoubtDto,
+  ): Promise<Doubt> {
+    return await this.doubtService.addNewDoubt(courseId, createDoubtDto);
   }
 
-  @Get('/:id')
-  async getDoubtbyID(@Param('id') id: string) {
-    return await this.doubtService.findDoubtById(id);
+  // edit the doubt by Id
+  @Put('/updateDoubt/:courseId/:doubtId')
+  async editDoubt(
+    @Param('courseId') courseId: Schema.Types.ObjectId,
+    @Param('doubtId') doubtId: Schema.Types.ObjectId,
+    @Body() updateDoubtDto: UpdateDoubtDto,
+  ): Promise<Doubt> {
+    return await this.doubtService.editDoubt(courseId, doubtId, updateDoubtDto);
   }
 
-  @ApiCreatedResponse({
-    type: CreateDoubtDto,
-    description: 'Create a new Doubt',
-  })
-  @Post('/new')
-  async askNewDoubt(@Body() createDoubt: CreateDoubtDto): Promise<Doubt> {
-    return await this.doubtService.addNewDoubt(createDoubt);
+  // Delete a doubt by Id
+  @Delete('/deleteDoubt/:courseId/:doubtId')
+  async deleteDoubt(
+    @Param('courseId') courseId: Schema.Types.ObjectId,
+    @Param('doubtId') doubtId: Schema.Types.ObjectId,
+  ): Promise<Doubt> {
+    return await this.doubtService.deleteDoubt(courseId, doubtId);
+  }
+
+  // add a new doubtAnswer
+  @Post('/newAnswer/:doubtId')
+  async askNewDoubtAnswer(
+    @Param('doubtId') doubtId: Schema.Types.ObjectId,
+    @Body() createDoubtAnswerDto: CreateDoubtAnswerDto,
+  ): Promise<DoubtAnswer> {
+    return await this.doubtService.addNewDoubtAnswer(
+      doubtId,
+      createDoubtAnswerDto,
+    );
+  }
+
+  // edit the doubtAnswer by Id
+  @Put('/updateDoubtAnswer/:doubtId/:doubtAnswerId')
+  async editDoubtAnswer(
+    @Param('doubtId') doubtId: Schema.Types.ObjectId,
+    @Param('doubtAnswerId') doubtAnswerId: Schema.Types.ObjectId,
+    @Body() updateDoubtAnswerDto: UpdateDoubtAnswerDto,
+  ): Promise<DoubtAnswer> {
+    return await this.doubtService.editDoubtAnswer(
+      doubtId,
+      doubtAnswerId,
+      updateDoubtAnswerDto,
+    );
+  }
+
+  // Delete a doubtAnswerby Id
+  @Delete('/deleteDoubtAnswer/:doubtId/:doubtAnswerId')
+  async deleteDoubtAnswer(
+    @Param('doubtId') doubtId: Schema.Types.ObjectId,
+    @Param('doubtAnswerId') doubtAnswerId: Schema.Types.ObjectId,
+  ): Promise<DoubtAnswer> {
+    return await this.doubtService.deleteDoubtAnswer(doubtId, doubtAnswerId);
   }
 }

--- a/src/modules/doubt/doubt.controller.ts
+++ b/src/modules/doubt/doubt.controller.ts
@@ -1,5 +1,10 @@
 import { Body, Controller, Delete, Param, Post, Put } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import {
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiParam,
+  ApiTags,
+} from '@nestjs/swagger';
 import { Schema } from 'mongoose';
 import { DoubtService } from './doubt.service';
 import { CreateDoubtDto } from './dto/create-doubt.dto';
@@ -8,6 +13,8 @@ import { UpdateDoubtDto } from './dto/update-doubt.dto';
 import { UpdateDoubtAnswerDto } from './dto/update-doubtAnswer.dto';
 import { DoubtDocument as Doubt } from './schema/doubt.schema';
 import { DoubtAnswer } from './schema/doubtAnswer.schema';
+import responsedoc from './docUtils/apidoc';
+import { courseId, doubtId, doubtAnswerId } from './docUtils/doubt.paramdocs';
 
 @ApiTags('Doubt')
 @Controller('doubt')
@@ -16,6 +23,8 @@ export class DoubtController {
 
   // add a new doubt
   @Post('/new/:courseId')
+  @ApiParam(courseId)
+  @ApiCreatedResponse(responsedoc.addDoubt)
   async askNewDoubt(
     @Param('courseId') courseId: Schema.Types.ObjectId,
     @Body() createDoubtDto: CreateDoubtDto,
@@ -25,6 +34,9 @@ export class DoubtController {
 
   // edit the doubt by Id
   @Put('/updateDoubt/:courseId/:doubtId')
+  @ApiParam(courseId)
+  @ApiParam(doubtId)
+  @ApiOkResponse(responsedoc.updateDoubt)
   async editDoubt(
     @Param('courseId') courseId: Schema.Types.ObjectId,
     @Param('doubtId') doubtId: Schema.Types.ObjectId,
@@ -35,6 +47,9 @@ export class DoubtController {
 
   // Delete a doubt by Id
   @Delete('/deleteDoubt/:courseId/:doubtId')
+  @ApiParam(courseId)
+  @ApiParam(doubtId)
+  @ApiOkResponse(responsedoc.deleteDoubt)
   async deleteDoubt(
     @Param('courseId') courseId: Schema.Types.ObjectId,
     @Param('doubtId') doubtId: Schema.Types.ObjectId,
@@ -44,6 +59,8 @@ export class DoubtController {
 
   // add a new doubtAnswer
   @Post('/newAnswer/:doubtId')
+  @ApiParam(doubtId)
+  @ApiCreatedResponse(responsedoc.addDoubtAnswer)
   async askNewDoubtAnswer(
     @Param('doubtId') doubtId: Schema.Types.ObjectId,
     @Body() createDoubtAnswerDto: CreateDoubtAnswerDto,
@@ -56,6 +73,9 @@ export class DoubtController {
 
   // edit the doubtAnswer by Id
   @Put('/updateDoubtAnswer/:doubtId/:doubtAnswerId')
+  @ApiParam(doubtId)
+  @ApiParam(doubtAnswerId)
+  @ApiOkResponse(responsedoc.updateDoubtAnswer)
   async editDoubtAnswer(
     @Param('doubtId') doubtId: Schema.Types.ObjectId,
     @Param('doubtAnswerId') doubtAnswerId: Schema.Types.ObjectId,
@@ -70,6 +90,9 @@ export class DoubtController {
 
   // Delete a doubtAnswerby Id
   @Delete('/deleteDoubtAnswer/:doubtId/:doubtAnswerId')
+  @ApiParam(doubtId)
+  @ApiParam(doubtAnswerId)
+  @ApiOkResponse(responsedoc.deleteDoubtAnswer)
   async deleteDoubtAnswer(
     @Param('doubtId') doubtId: Schema.Types.ObjectId,
     @Param('doubtAnswerId') doubtAnswerId: Schema.Types.ObjectId,

--- a/src/modules/doubt/doubt.module.ts
+++ b/src/modules/doubt/doubt.module.ts
@@ -3,10 +3,16 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { DoubtSchema } from './schema/doubt.schema';
 import { DoubtController } from './doubt.controller';
 import { DoubtService } from './doubt.service';
+import { CourseSchema } from 'modules/course/schema/course.schema';
+import { DoubtAnswerSchema } from './schema/doubtAnswer.schema';
 
 @Module({
   imports: [
-    MongooseModule.forFeature([{ name: 'Doubt', schema: DoubtSchema }]),
+    MongooseModule.forFeature([
+      { name: 'Doubt', schema: DoubtSchema },
+      { name: 'DoubtAnswer', schema: DoubtAnswerSchema },
+      { name: 'Course', schema: CourseSchema },
+    ]),
   ],
   controllers: [DoubtController],
   providers: [DoubtService],

--- a/src/modules/doubt/doubt.service.spec.ts
+++ b/src/modules/doubt/doubt.service.spec.ts
@@ -12,6 +12,14 @@ describe('DoubtService', () => {
           provide: getModelToken('Doubt'),
           useValue: {},
         },
+        {
+          provide: getModelToken('Course'),
+          useValue: {},
+        },
+        {
+          provide: getModelToken('DoubtAnswer'),
+          useValue: {},
+        },
       ],
     }).compile();
     service = module.get<DoubtService>(DoubtService);

--- a/src/modules/doubt/doubt.service.ts
+++ b/src/modules/doubt/doubt.service.ts
@@ -4,41 +4,187 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { Model } from 'mongoose';
+import { Model, Schema } from 'mongoose';
 import { CreateDoubtDto } from './dto/create-doubt.dto';
 import { DoubtDocument as Doubt } from './schema/doubt.schema';
+import { Course } from 'modules/course/schema/course.schema';
+import { UpdateDoubtDto } from './dto/update-doubt.dto';
+import { DoubtAnswer } from './schema/doubtAnswer.schema';
+import { UpdateDoubtAnswerDto } from './dto/update-doubtAnswer.dto';
+import { CreateDoubtAnswerDto } from './dto/create-doubtAnswer.dto';
 
 @Injectable()
 export class DoubtService {
   constructor(
     @InjectModel('Doubt') private readonly DoubtModel: Model<Doubt>,
+    @InjectModel('Course') private readonly CourseModel: Model<Course>,
+    @InjectModel('DoubtAnswer')
+    private readonly DoubtAnswerModel: Model<DoubtAnswer>,
   ) {}
 
-  async getAllDoubts(): Promise<Doubt[]> {
+  // add a new doubt
+  async addNewDoubt(
+    courseId: Schema.Types.ObjectId,
+    createDoubtDto: CreateDoubtDto,
+  ) {
     try {
-      return await this.DoubtModel.find().exec();
-    } catch (e) {
-      throw new InternalServerErrorException(e);
-    }
-  }
-
-  async findDoubtById(id: string): Promise<Doubt> {
-    try {
-      const doubt = await this.DoubtModel.findById(id).exec();
-
-      if (doubt) {
-        return doubt;
+      const course = await this.CourseModel.findById(courseId);
+      if (course) {
+        const newDoubt = await new this.DoubtModel(createDoubtDto).save();
+        course.doubts.push(newDoubt);
+        await course.save();
+        return newDoubt.populate('answers');
+      } else {
+        throw new NotFoundException(
+          'The course id is invalid or the course no longer exists',
+        );
       }
     } catch (e) {
       throw new InternalServerErrorException(e);
     }
-
-    throw new NotFoundException('doubt not found!');
   }
 
-  async addNewDoubt(newDoubt: CreateDoubtDto) {
+  // edit the doubt by Id
+  async editDoubt(
+    courseId: Schema.Types.ObjectId,
+    doubtId: Schema.Types.ObjectId,
+    updateDoubtDto: UpdateDoubtDto,
+  ) {
     try {
-      return await new this.DoubtModel(newDoubt).save();
+      const course = await this.CourseModel.findById(courseId);
+      if (course) {
+        let updatedDoubt = null;
+        updatedDoubt = await this.DoubtModel.findByIdAndUpdate(
+          doubtId,
+          updateDoubtDto,
+          { new: true },
+        );
+        if (updatedDoubt) {
+          return updatedDoubt;
+        } else {
+          throw new NotFoundException(
+            'The doubt id is invalid or the doubt no longer exists',
+          );
+        }
+      } else {
+        throw new NotFoundException(
+          'The course id is invalid or the course no longer exists',
+        );
+      }
+    } catch (e) {
+      throw new InternalServerErrorException(e);
+    }
+  }
+
+  // Delete a doubt by Id
+  async deleteDoubt(
+    courseId: Schema.Types.ObjectId,
+    doubtId: Schema.Types.ObjectId,
+  ): Promise<any> {
+    try {
+      const course = await this.CourseModel.findById(courseId);
+      if (course) {
+        let deletedDoubt = null;
+        deletedDoubt = await this.DoubtModel.findByIdAndRemove(
+          doubtId,
+        ).populate('answers');
+        if (deletedDoubt) {
+          return deletedDoubt;
+        } else {
+          throw new NotFoundException(
+            'The doubt id is invalid or the doubt no longer exists',
+          );
+        }
+      } else {
+        throw new NotFoundException(
+          'The course id is invalid or the course no longer exists',
+        );
+      }
+    } catch (e) {
+      throw new InternalServerErrorException(e);
+    }
+  }
+
+  // add a new doubtAnswer
+  async addNewDoubtAnswer(
+    doubtId: Schema.Types.ObjectId,
+    createDoubtAnswerDto: CreateDoubtAnswerDto,
+  ) {
+    try {
+      const doubt = await this.DoubtModel.findById(doubtId);
+      if (doubt) {
+        const newDoubtAnswer = await new this.DoubtAnswerModel(
+          createDoubtAnswerDto,
+        ).save();
+        doubt.answers.push(newDoubtAnswer);
+        await doubt.save();
+        return newDoubtAnswer;
+      } else {
+        throw new NotFoundException(
+          'The doubt id is invalid or the doubt no longer exists',
+        );
+      }
+    } catch (e) {
+      throw new InternalServerErrorException(e);
+    }
+  }
+
+  // edit the doubtAnswer by Id
+  async editDoubtAnswer(
+    doubtId: Schema.Types.ObjectId,
+    doubtAnswerId: Schema.Types.ObjectId,
+    updateDoubtAnswerDto: UpdateDoubtAnswerDto,
+  ) {
+    try {
+      const doubt = await this.DoubtModel.findById(doubtId);
+      if (doubt) {
+        let updatedDoubt = null;
+        updatedDoubt = await this.DoubtAnswerModel.findByIdAndUpdate(
+          doubtAnswerId,
+          updateDoubtAnswerDto,
+          { new: true },
+        );
+        if (updatedDoubt) {
+          return updatedDoubt;
+        } else {
+          throw new NotFoundException(
+            'The doubtAnswerId id is invalid or the doubtAnswerId no longer exists',
+          );
+        }
+      } else {
+        throw new NotFoundException(
+          'The doubt id is invalid or the doubt no longer exists',
+        );
+      }
+    } catch (e) {
+      throw new InternalServerErrorException(e);
+    }
+  }
+
+  // Delete a doubtAnswer by Id
+  async deleteDoubtAnswer(
+    doubtId: Schema.Types.ObjectId,
+    doubtAnswerId: Schema.Types.ObjectId,
+  ): Promise<any> {
+    try {
+      const doubt = await this.DoubtModel.findById(doubtId);
+      if (doubt) {
+        let deletedDoubt = null;
+        deletedDoubt = await this.DoubtAnswerModel.findByIdAndRemove(
+          doubtAnswerId,
+        );
+        if (deletedDoubt) {
+          return deletedDoubt;
+        } else {
+          throw new NotFoundException(
+            'The doubtAnswerId id is invalid or the doubtAnswerId no longer exists',
+          );
+        }
+      } else {
+        throw new NotFoundException(
+          'The doubt id is invalid or the doubt no longer exists',
+        );
+      }
     } catch (e) {
       throw new InternalServerErrorException(e);
     }

--- a/src/modules/doubt/dto/create-doubtAnswer.dto.ts
+++ b/src/modules/doubt/dto/create-doubtAnswer.dto.ts
@@ -1,0 +1,17 @@
+import {
+  IsBoolean,
+  IsEnum,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+} from 'class-validator';
+
+export class CreateDoubtAnswerDto {
+  @IsString()
+  @IsNotEmpty()
+  answered_by: string;
+
+  @IsString()
+  @IsNotEmpty()
+  answer: string;
+}

--- a/src/modules/doubt/dto/create-doubtAnswer.dto.ts
+++ b/src/modules/doubt/dto/create-doubtAnswer.dto.ts
@@ -1,10 +1,4 @@
-import {
-  IsBoolean,
-  IsEnum,
-  IsNotEmpty,
-  IsOptional,
-  IsString,
-} from 'class-validator';
+import { IsNotEmpty, IsString } from 'class-validator';
 
 export class CreateDoubtAnswerDto {
   @IsString()

--- a/src/modules/doubt/dto/update-doubt.dto.ts
+++ b/src/modules/doubt/dto/update-doubt.dto.ts
@@ -7,7 +7,7 @@ import {
 } from 'class-validator';
 import { TagType } from '../doubt-tag.enum';
 
-export class CreateDoubtDto {
+export class UpdateDoubtDto {
   @IsNotEmpty()
   @IsEnum(TagType)
   tags: TagType[];

--- a/src/modules/doubt/dto/update-doubtAnswer.dto.ts
+++ b/src/modules/doubt/dto/update-doubtAnswer.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class UpdateDoubtAnswerDto {
+  @IsString()
+  @IsNotEmpty()
+  answered_by: string;
+
+  @IsString()
+  @IsNotEmpty()
+  answer: string;
+}

--- a/src/modules/doubt/schema/doubt.schema.ts
+++ b/src/modules/doubt/schema/doubt.schema.ts
@@ -1,26 +1,42 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import * as mongoose from 'mongoose';
-import { User } from '../../user/schema/user.schema';
 import { Schema as SchemaType } from 'mongoose';
+import { TagType } from '../doubt-tag.enum';
+import { DoubtAnswer } from './doubtAnswer.schema';
 
 export type DoubtDocument = Doubt & mongoose.Document;
 
 @Schema()
 export class Doubt {
   @Prop({ required: true })
-  tags: string[];
+  tags: TagType[];
 
-  @Prop({ type: SchemaType.Types.ObjectId, ref: 'User' })
-  asked_by: User;
+  @Prop({ required: true })
+  asked_by: string;
 
-  @Prop()
-  answers: string[];
+  @Prop({ type: [{ type: SchemaType.Types.ObjectId, ref: 'DoubtAnswer' }] })
+  answers: DoubtAnswer[];
+
+  @Prop({ required: true })
+  question: string;
 
   @Prop({ default: false })
   is_resolved: boolean;
 
-  @Prop()
+  @Prop({ required: true })
   request_mentor: boolean;
 }
 
 export const DoubtSchema = SchemaFactory.createForClass(Doubt);
+
+DoubtSchema.methods.toJSON = function () {
+  const doubtObject = this.toObject();
+  doubtObject.id = doubtObject._id;
+
+  delete doubtObject._id;
+  delete doubtObject.__v;
+  delete doubtObject['createdAt'];
+  delete doubtObject['updatedAt'];
+
+  return doubtObject;
+};

--- a/src/modules/doubt/schema/doubtAnswer.schema.ts
+++ b/src/modules/doubt/schema/doubtAnswer.schema.ts
@@ -1,0 +1,27 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import * as mongoose from 'mongoose';
+
+export type DoubtAnswerDocument = DoubtAnswer & mongoose.Document;
+
+@Schema()
+export class DoubtAnswer {
+  @Prop({ required: true })
+  answered_by: string;
+
+  @Prop({ required: true })
+  answer: string;
+}
+
+export const DoubtAnswerSchema = SchemaFactory.createForClass(DoubtAnswer);
+
+DoubtAnswerSchema.methods.toJSON = function () {
+  const doubtAnswerObject = this.toObject();
+  doubtAnswerObject.id = doubtAnswerObject._id;
+
+  delete doubtAnswerObject._id;
+  delete doubtAnswerObject.__v;
+  delete doubtAnswerObject['createdAt'];
+  delete doubtAnswerObject['updatedAt'];
+
+  return doubtAnswerObject;
+};


### PR DESCRIPTION
Add API endpoint documentation for doubts and doubtAnswers

1). adds APIPARAMS of courseid, doubtId, doubtAnswerId
2). add responsedoc
3). filled the example values for both doubts and doubt answer in for the swagger documnetation

**Type of Change:**


- [x] Code
- [x] New Feature
- [x] Documentation


**How Has This Been Tested?**

Terminal commands to test code:-
1). npm run lint
2). npm run lint:fix
3). nest start
4). npm run test

**Checklist**

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] My changes generate no new warnings
- [x] The title of my pull request is a short description of the requested changes.




