### PR TITLE
Documentation of Doubts and DoubtsAnswer endpoints

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -52,6 +52,14 @@ export class AppModule {
           method: RequestMethod.GET,
         },
         {
+          path: 'Doubt/(.*)',
+          method: RequestMethod.GET,
+        },
+        {
+          path: 'Doubt',
+          method: RequestMethod.GET,
+        },
+        {
           path: 'Announcement/(.*)',
           method: RequestMethod.GET,
         },

--- a/src/modules/course/course.service.ts
+++ b/src/modules/course/course.service.ts
@@ -65,7 +65,7 @@ export class CourseService {
     try {
       return await this.CourseModel.find()
         .select(
-          'name courseShortDescription tags rating no_of_enrollments mentor crossPrice courseLevel courseThumbnail duration reviews video_num',
+          'name courseShortDescription tags rating no_of_enrollments mentor crossPrice courseLevel courseThumbnail duration reviews video_num isUpcoming',
         )
         .populate('reviews')
         .lean();

--- a/src/modules/doubt/docUtils/apidoc.ts
+++ b/src/modules/doubt/docUtils/apidoc.ts
@@ -1,0 +1,63 @@
+import DoubtResponseBody, {
+  DoubtAnswerResponseBody,
+} from './doubt.responsedoc';
+import { ApiResponseOptions } from '@nestjs/swagger';
+
+const addDoubt: ApiResponseOptions = {
+  description: 'Add a doubt',
+  type: DoubtResponseBody,
+};
+
+const updateDoubt: ApiResponseOptions = {
+  description: 'Update a doubt',
+  type: DoubtResponseBody,
+};
+
+const deleteDoubt: ApiResponseOptions = {
+  description: 'Delete a doubt',
+  type: DoubtResponseBody,
+};
+
+const addDoubtAnswer: ApiResponseOptions = {
+  description: 'Add a doubt Answer',
+  type: DoubtAnswerResponseBody,
+};
+
+const updateDoubtAnswer: ApiResponseOptions = {
+  description: 'Update a doubt Answer',
+  type: DoubtAnswerResponseBody,
+};
+
+const deleteDoubtAnswer: ApiResponseOptions = {
+  description: 'Delete a doubt Answer',
+  type: DoubtAnswerResponseBody,
+};
+
+const getDoubtsForSelectedCourse: ApiResponseOptions = {
+  description: 'Get doubts for coursesr',
+  type: [DoubtResponseBody],
+};
+
+const getAllDoubts: ApiResponseOptions = {
+  description: 'Retrieve doubts list',
+  type: [DoubtResponseBody],
+};
+
+const getDoubtById: ApiResponseOptions = {
+  description: 'Delete a doubt Answer',
+  type: DoubtResponseBody,
+};
+
+const responses = {
+  addDoubt,
+  updateDoubt,
+  deleteDoubt,
+  addDoubtAnswer,
+  updateDoubtAnswer,
+  deleteDoubtAnswer,
+  getDoubtsForSelectedCourse,
+  getAllDoubts,
+  getDoubtById,
+};
+
+export default responses;

--- a/src/modules/doubt/docUtils/apidoc.ts
+++ b/src/modules/doubt/docUtils/apidoc.ts
@@ -34,7 +34,7 @@ const deleteDoubtAnswer: ApiResponseOptions = {
 };
 
 const getDoubtsForSelectedCourse: ApiResponseOptions = {
-  description: 'Get doubts for coursesr',
+  description: 'Get doubts for courses',
   type: [DoubtResponseBody],
 };
 
@@ -44,7 +44,7 @@ const getAllDoubts: ApiResponseOptions = {
 };
 
 const getDoubtById: ApiResponseOptions = {
-  description: 'Delete a doubt Answer',
+  description: 'get doubt by Id',
   type: DoubtResponseBody,
 };
 

--- a/src/modules/doubt/docUtils/doubt.paramdocs.ts
+++ b/src/modules/doubt/docUtils/doubt.paramdocs.ts
@@ -1,0 +1,22 @@
+import { ApiParamOptions } from '@nestjs/swagger';
+
+export const courseId: ApiParamOptions = {
+  name: 'courseId',
+  type: String,
+  description: 'Course Id in the form of MongoId',
+  example: '60ccf3758dc53371bd4d0154',
+};
+
+export const doubtId: ApiParamOptions = {
+  name: 'doubtId',
+  type: String,
+  description: 'Doubt Id in the form of MongoId',
+  example: '60ccf3758dc53371bd4d0154',
+};
+
+export const doubtAnswerId: ApiParamOptions = {
+  name: 'doubtAnswerId',
+  type: String,
+  description: 'DoubtAnswer Id in the form of MongoId',
+  example: '60ccf3758dc53371bd4d0154',
+};

--- a/src/modules/doubt/docUtils/doubt.responsedoc.ts
+++ b/src/modules/doubt/docUtils/doubt.responsedoc.ts
@@ -1,0 +1,66 @@
+import { TagType } from '../doubt-tag.enum';
+import { DoubtAnswer } from '../schema/doubtAnswer.schema';
+
+export default class DoubtResponseBody {
+  /**
+   * DoubtId
+   * @example 60ccf3037025096f45cb87bf
+   */
+  id: string;
+
+  /**
+   * The name of the person who asked the doubt
+   * @example '60ccf3037025096f45cb87bf'
+   */
+  asked_by: string;
+
+  /**
+   * The Answer of the doubt
+   * @example []
+   */
+  answers: DoubtAnswer[];
+
+  /**
+   * Whether the metor's assistance is needed or not for the doubt
+   * @example true
+   */
+  request_mentor: boolean;
+
+  /**
+   * Whether the doubt was resolved or not
+   * @example true
+   */
+  is_resolved: boolean;
+
+  /**
+   * The question/doubt
+   * @example "Why do we use memoization over tabulation ?"
+   */
+  question: string;
+
+  /**
+   * The tags associated with the doubt
+   * @example ["Web development"]
+   */
+  tags: TagType[];
+}
+
+export class DoubtAnswerResponseBody {
+  /**
+   * DoubtAnswerId
+   * @example '60ccf3037025096f45cb87bf'
+   */
+  id: string;
+
+  /**
+   * The name of the person who answered the doubt
+   * @example '60ccf3037025096f45cb87bf'
+   */
+  answered_by: string;
+
+  /**
+   * The asnwer to the doubt
+   * @example "We use this to conserve time by applying alogorithm of lesser time complexity"
+   */
+  answer: string;
+}

--- a/src/modules/doubt/doubt.controller.ts
+++ b/src/modules/doubt/doubt.controller.ts
@@ -7,8 +7,16 @@ import {
   Post,
   Put,
 } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import {
+  ApiCreatedResponse,
+  ApiOkResponse,
+  ApiOperation,
+  ApiParam,
+  ApiTags,
+} from '@nestjs/swagger';
+import { courseId, doubtAnswerId, doubtId } from './docUtils/doubt.paramdocs';
 import { Schema } from 'mongoose';
+import responsedoc from './docUtils/apidoc';
 import { DoubtService } from './doubt.service';
 import { CreateDoubtDto } from './dto/create-doubt.dto';
 import { CreateDoubtAnswerDto } from './dto/create-doubtAnswer.dto';
@@ -22,28 +30,35 @@ import { DoubtAnswer } from './schema/doubtAnswer.schema';
 export class DoubtController {
   constructor(private doubtService: DoubtService) {}
 
-  // Retrieve doubts list
   @Get()
+  @ApiOkResponse(responsedoc.getAllDoubts)
+  @ApiOperation({ summary: 'Retrieve doubts list' })
   async getAllDoubts() {
     return await this.doubtService.getAllDoubts();
   }
 
-  // Retrieve doubt by id
   @Get('/get/:doubtId')
+  @ApiParam(doubtId)
+  @ApiOkResponse(responsedoc.getDoubtById)
+  @ApiOperation({ summary: 'Retrieve doubt by id' })
   async getDoubtById(@Param('doubtId') doubtId: Schema.Types.ObjectId) {
     return await this.doubtService.getDoubtById(doubtId);
   }
 
-  // get doubts for courses
   @Get('/get/:courseId')
+  @ApiParam(courseId)
+  @ApiOkResponse(responsedoc.getDoubtById)
+  @ApiOperation({ summary: 'Retrieve doubts for courses' })
   async getDoubtsForSelectedCourse(
     @Param('courseId') courseId: Schema.Types.ObjectId,
   ): Promise<Doubt> {
     return await this.doubtService.findDoubtsForSelectedCourse(courseId);
   }
 
-  // add a new doubt
   @Post('/new/:courseId')
+  @ApiParam(courseId)
+  @ApiCreatedResponse(responsedoc.addDoubt)
+  @ApiOperation({ summary: 'Add a new doubt' })
   async askNewDoubt(
     @Param('courseId') courseId: Schema.Types.ObjectId,
     @Body() createDoubtDto: CreateDoubtDto,
@@ -51,8 +66,11 @@ export class DoubtController {
     return await this.doubtService.addNewDoubt(courseId, createDoubtDto);
   }
 
-  // edit the doubt by Id
   @Put('/updateDoubt/:courseId/:doubtId')
+  @ApiParam(courseId)
+  @ApiParam(doubtId)
+  @ApiCreatedResponse(responsedoc.updateDoubt)
+  @ApiOperation({ summary: 'Edit doubt by id' })
   async editDoubt(
     @Param('courseId') courseId: Schema.Types.ObjectId,
     @Param('doubtId') doubtId: Schema.Types.ObjectId,
@@ -61,8 +79,10 @@ export class DoubtController {
     return await this.doubtService.editDoubt(courseId, doubtId, updateDoubtDto);
   }
 
-  // Delete a doubt by Id
   @Delete('/deleteDoubt/:courseId/:doubtId')
+  @ApiParam(courseId)
+  @ApiParam(doubtId)
+  @ApiCreatedResponse(responsedoc.deleteDoubt)
   async deleteDoubt(
     @Param('courseId') courseId: Schema.Types.ObjectId,
     @Param('doubtId') doubtId: Schema.Types.ObjectId,
@@ -70,8 +90,10 @@ export class DoubtController {
     return await this.doubtService.deleteDoubt(courseId, doubtId);
   }
 
-  // add a new doubtAnswer
   @Post('/newAnswer/:doubtId')
+  @ApiParam(doubtId)
+  @ApiCreatedResponse(responsedoc.addDoubtAnswer)
+  @ApiOperation({ summary: 'Add a new doubt Answer' })
   async askNewDoubtAnswer(
     @Param('doubtId') doubtId: Schema.Types.ObjectId,
     @Body() createDoubtAnswerDto: CreateDoubtAnswerDto,
@@ -84,6 +106,10 @@ export class DoubtController {
 
   // edit the doubtAnswer by Id
   @Put('/updateDoubtAnswer/:doubtId/:doubtAnswerId')
+  @ApiParam(doubtAnswerId)
+  @ApiParam(doubtId)
+  @ApiCreatedResponse(responsedoc.updateDoubtAnswer)
+  @ApiOperation({ summary: 'Edit doubt Answer by id' })
   async editDoubtAnswer(
     @Param('doubtId') doubtId: Schema.Types.ObjectId,
     @Param('doubtAnswerId') doubtAnswerId: Schema.Types.ObjectId,
@@ -98,6 +124,10 @@ export class DoubtController {
 
   // Delete a doubtAnswerby Id
   @Delete('/deleteDoubtAnswer/:doubtId/:doubtAnswerId')
+  @ApiParam(doubtAnswerId)
+  @ApiParam(doubtId)
+  @ApiCreatedResponse(responsedoc.deleteDoubtAnswer)
+  @ApiOperation({ summary: 'Delete doubt Answer by id' })
   async deleteDoubtAnswer(
     @Param('doubtId') doubtId: Schema.Types.ObjectId,
     @Param('doubtAnswerId') doubtAnswerId: Schema.Types.ObjectId,

--- a/src/modules/doubt/doubt.controller.ts
+++ b/src/modules/doubt/doubt.controller.ts
@@ -104,7 +104,6 @@ export class DoubtController {
     );
   }
 
-  // edit the doubtAnswer by Id
   @Put('/updateDoubtAnswer/:doubtId/:doubtAnswerId')
   @ApiParam(doubtAnswerId)
   @ApiParam(doubtId)
@@ -122,7 +121,6 @@ export class DoubtController {
     );
   }
 
-  // Delete a doubtAnswerby Id
   @Delete('/deleteDoubtAnswer/:doubtId/:doubtAnswerId')
   @ApiParam(doubtAnswerId)
   @ApiParam(doubtId)

--- a/src/modules/doubt/dto/create-doubt.dto.ts
+++ b/src/modules/doubt/dto/create-doubt.dto.ts
@@ -12,26 +12,46 @@ import { Schema } from 'mongoose';
 import { TagType } from '../doubt-tag.enum';
 
 export class CreateDoubtDto {
+  /**
+   * The tags associated with the doubt
+   * @example ["Web development"]
+   */
   @IsNotEmpty()
   @IsArray()
   @IsEnum(TagType, { each: true })
-  tags: TagType[];
+  tags?: TagType[];
 
+  /**
+   * The name of the person who asked the doubt
+   * @example '60ccf3037025096f45cb87bf'
+   */
   @IsNotEmpty()
   @IsMongoId()
   @IsNotEmpty()
   @ApiProperty({ type: Schema.Types.ObjectId })
   asked_by: Schema.Types.ObjectId;
 
+  /**
+   * The question/doubt
+   * @example "Why do we use memoization over tabulation ?"
+   */
   @IsString()
   @IsNotEmpty()
   question: string;
 
+  /**
+   * Whether the metor's assistance is needed or not for the doubt
+   * @example true
+   */
   @IsBoolean()
   @IsOptional()
   @IsNotEmpty()
-  request_mentor: boolean;
+  request_mentor?: boolean;
 
+  /**
+   * Whether the doubt was resolved or not
+   * @example true
+   */
   @IsBoolean()
   @IsOptional()
   @IsNotEmpty()

--- a/src/modules/doubt/dto/create-doubtAnswer.dto.ts
+++ b/src/modules/doubt/dto/create-doubtAnswer.dto.ts
@@ -3,12 +3,20 @@ import { IsMongoId, IsNotEmpty, IsString } from 'class-validator';
 import { Schema } from 'mongoose';
 
 export class CreateDoubtAnswerDto {
+  /**
+   * The name of the person who answered the doubt
+   * @example '60ccf3037025096f45cb87bf'
+   */
   @IsNotEmpty()
   @IsMongoId()
   @IsNotEmpty()
   @ApiProperty({ type: Schema.Types.ObjectId })
   answered_by: Schema.Types.ObjectId;
 
+  /**
+   * The asnwer to the doubt
+   * @example "We use this to conserve time by applying alogorithm of lesser time complexity"
+   */
   @IsString()
   @IsNotEmpty()
   answer: string;

--- a/src/modules/doubt/dto/update-doubt.dto.ts
+++ b/src/modules/doubt/dto/update-doubt.dto.ts
@@ -12,26 +12,46 @@ import { Schema } from 'mongoose';
 import { TagType } from '../doubt-tag.enum';
 
 export class UpdateDoubtDto {
+  /**
+   * The tags associated with the doubt
+   * @example ["Web development"]
+   */
   @IsNotEmpty()
   @IsArray()
   @IsEnum(TagType, { each: true })
-  tags: TagType[];
+  tags?: TagType[];
 
+  /**
+   * The name of the person who asked the doubt
+   * @example '60ccf3037025096f45cb87bf'
+   */
   @IsNotEmpty()
   @IsMongoId()
   @IsNotEmpty()
   @ApiProperty({ type: Schema.Types.ObjectId })
   asked_by: Schema.Types.ObjectId;
 
+  /**
+   * The question/doubt
+   * @example "Why do we use memoization over tabulation ?"
+   */
   @IsString()
   @IsNotEmpty()
   question: string;
 
+  /**
+   * Whether the metor's assistance is needed or not for the doubt
+   * @example true
+   */
   @IsBoolean()
   @IsOptional()
   @IsNotEmpty()
-  request_mentor: boolean;
+  request_mentor?: boolean;
 
+  /**
+   * Whether the doubt was resolved or not
+   * @example true
+   */
   @IsBoolean()
   @IsOptional()
   @IsNotEmpty()

--- a/src/modules/doubt/dto/update-doubtAnswer.dto.ts
+++ b/src/modules/doubt/dto/update-doubtAnswer.dto.ts
@@ -3,12 +3,20 @@ import { IsMongoId, IsNotEmpty, IsString } from 'class-validator';
 import { Schema } from 'mongoose';
 
 export class UpdateDoubtAnswerDto {
+  /**
+   * The name of the person who answered the doubt
+   * @example '60ccf3037025096f45cb87bf'
+   */
   @IsNotEmpty()
   @IsMongoId()
   @IsNotEmpty()
   @ApiProperty({ type: Schema.Types.ObjectId })
   answered_by: Schema.Types.ObjectId;
 
+  /**
+   * The asnwer to the doubt
+   * @example "We use this to conserve time by applying alogorithm of lesser time complexity"
+   */
   @IsString()
   @IsNotEmpty()
   answer: string;

--- a/src/modules/doubt/schema/doubt.schema.ts
+++ b/src/modules/doubt/schema/doubt.schema.ts
@@ -8,7 +8,7 @@ export type DoubtDocument = Doubt & Document;
 
 @Schema({ timestamps: true })
 export class Doubt {
-  @Prop({ required: true })
+  @Prop()
   tags: TagType[];
 
   @Prop({ required: true })
@@ -23,7 +23,7 @@ export class Doubt {
   @Prop({ default: false })
   is_resolved: boolean;
 
-  @Prop({ required: true })
+  @Prop()
   request_mentor: boolean;
 }
 


### PR DESCRIPTION
Add API endpoint documentation for doubts and doubtAnswers

1). adds APIPARAMS of courseid, doubtId, doubtAnswerId
2). add responsedoc
3). filled the example values for both doubts and doubt answer in for the swagger documentation
4). Add Api operations as well
5). Also added exclusion of get requests from doubs path from middleware
6). add isUpcoming to be returned for cards as well

**Type of Change:**


- [x] Code
- [x] New Feature
- [x] Documentation


**How Has This Been Tested?**

Terminal commands to test code:-
1). npm run lint
2). npm run lint:fix
3). nest start
4). npm run test

**Checklist**

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] My changes generate no new warnings
- [x] The title of my pull request is a short description of the requested changes.


