### PR TITLE
Fix failing tests [Hot-Fix] and some refactor and mentor population in course endpoint and other changes

### DIFF
--- a/src/modules/course/course.controller.spec.ts
+++ b/src/modules/course/course.controller.spec.ts
@@ -139,7 +139,6 @@ describe('CourseController', () => {
     it('should be updated', async () => {
       const id = new mongoose.Schema.Types.ObjectId('22', 0, 'rtex');
       const dto: UpdateCourseDTO = {
-        mentor: [],
         active: false,
         name: 'devesh K',
         originalPrice: 0,
@@ -168,6 +167,7 @@ describe('CourseController', () => {
       };
       await expect(controller.updateCourse(id, dto)).resolves.toEqual({
         id,
+        mentor: [],
         ...dto,
         schedule: [],
       });
@@ -179,7 +179,6 @@ describe('CourseController', () => {
       const id = new mongoose.Schema.Types.ObjectId('18', 0, 'riep');
       const idFix = new mongoose.Schema.Types.ObjectId('22', 0, 'rtex');
       const dto: UpdateCourseDTO = {
-        mentor: [],
         active: false,
         name: 'devesh K',
         originalPrice: 0,

--- a/src/modules/course/course.controller.ts
+++ b/src/modules/course/course.controller.ts
@@ -207,4 +207,15 @@ export class CourseController {
   ) {
     return await this.courseService.deleteLecture(scheduleId, lectureId);
   }
+
+  @Post('/mentor/:courseId/:mentorId')
+  @ApiOperation({ summary: 'Add a mentor to course' })
+  @ApiCreatedResponse(responsedoc.addMentorToCourse)
+  @ApiParam(courseId)
+  async addMentorToCourse(
+    @Param('courseId') courseId: Schema.Types.ObjectId,
+    @Param('mentorId') mentorId: Schema.Types.ObjectId,
+  ) {
+    return await this.courseService.addMentorToCourse(courseId, mentorId);
+  }
 }

--- a/src/modules/course/course.module.ts
+++ b/src/modules/course/course.module.ts
@@ -9,6 +9,7 @@ import { DoubtSchema } from '../doubt/schema/doubt.schema';
 import { DoubtAnswerSchema } from '../doubt/schema/doubtAnswer.schema';
 import { AssignmentSchema } from '../assignment/schema/assignment.schema';
 import { LectureSchema } from './schema/lecture.schema';
+import { MentorSchema } from 'modules/mentor/schema/mentor.schema';
 
 @Module({
   imports: [
@@ -20,6 +21,7 @@ import { LectureSchema } from './schema/lecture.schema';
       { name: 'DoubtAnswer', schema: DoubtAnswerSchema },
       { name: 'Assignment', schema: AssignmentSchema },
       { name: 'Lecture', schema: LectureSchema },
+      { name: 'Mentor', schema: MentorSchema },
     ]),
   ],
   controllers: [CourseController],

--- a/src/modules/course/course.service.spec.ts
+++ b/src/modules/course/course.service.spec.ts
@@ -21,7 +21,7 @@ const mockCourse = (
   start_date = new Date('2020-02-05T06:35:22.000Z'),
   end_date = new Date('2020-02-05T06:35:22.000Z'),
   sharable_link = 'https://88900xyz.com',
-  mentor = ['6079f573062890a5e2cad200'],
+  mentor = [],
   tags = [TagType.WEB_DEV],
   courseDetails = 'The course gives a hands on learning experience on Rest APIs and Javascript',
   courseLevel = courseLevelType.BEGINNER,
@@ -160,6 +160,10 @@ describe('CourseService', () => {
           provide: getModelToken('Lecture'),
           useValue: {},
         },
+        {
+          provide: getModelToken('Mentor'),
+          useValue: {},
+        },
       ],
     }).compile();
 
@@ -181,9 +185,7 @@ describe('CourseService', () => {
 
   describe('Testing courseservice after mock', () => {
     const _id = '60bca010d17d463dd09baf9b';
-    const courseDocArray = [
-      mockCourseDoc({ mentor: ['6079f573062890a5e2cad200'] }, _id),
-    ];
+    const courseDocArray = [mockCourseDoc({}, _id)];
 
     // Test for testing the service for returning all courses
     it('should return all courses', async () => {
@@ -259,7 +261,6 @@ describe('CourseService', () => {
         start_date: new Date('2020-02-05T06:35:22.000Z'),
         end_date: new Date('2020-02-05T06:35:22.000Z'),
         sharable_link: 'https://java.com',
-        mentor: [],
         tags: [TagType.WEB_DEV],
         courseDetails:
           'The course gives a hands on learning experience on Rest APIs and Javascript',

--- a/src/modules/course/course.service.ts
+++ b/src/modules/course/course.service.ts
@@ -114,6 +114,14 @@ export class CourseService {
             model: 'Lecture',
           },
         })
+        .populate({
+          path: 'doubts',
+          model: 'Doubt',
+          populate: {
+            path: 'answers',
+            model: 'DoubtAnswer',
+          },
+        })
         .exec();
       if (Course) {
         return Course;

--- a/src/modules/course/docUtils/apidoc.ts
+++ b/src/modules/course/docUtils/apidoc.ts
@@ -79,6 +79,11 @@ const deleteLecture: ApiResponseOptions = {
   type: LectureResponseBody,
 };
 
+const addMentorToCourse: ApiResponseOptions = {
+  description: 'Add mentor to the course',
+  type: CourseResponseBody,
+};
+
 const responses = {
   getAllCourses,
   getSelectedCourses,
@@ -95,6 +100,7 @@ const responses = {
   addLecture,
   updateLecture,
   deleteLecture,
+  addMentorToCourse,
 };
 
 export default responses;

--- a/src/modules/course/dto/course-update.dto.ts
+++ b/src/modules/course/dto/course-update.dto.ts
@@ -80,13 +80,6 @@ export class UpdateCourseDTO {
   readonly sharable_link: string;
 
   /**
-   * The Mentor of the course
-   * @example ['John Doe']
-   */
-  @IsArray()
-  mentor?: string[];
-
-  /**
    * The number of enrollments of the course
    * @example 100001
    */

--- a/src/modules/course/dto/create-mentor.dto.ts
+++ b/src/modules/course/dto/create-mentor.dto.ts
@@ -1,0 +1,57 @@
+import {
+  IsArray,
+  IsEmail,
+  IsNotEmpty,
+  IsNumber,
+  IsString,
+  IsUrl,
+} from 'class-validator';
+
+export class CreateMentorDTO {
+  /**
+   * name of the mentor
+   * @example 'Anuj Garg'
+   */
+  @IsNotEmpty()
+  @IsString()
+  name: string;
+
+  /**
+   * Email of the mentor
+   * @example 'anuj@codeforcause.org'
+   */
+  @IsNotEmpty()
+  @IsEmail()
+  email: string;
+
+  /**
+   * number of students under the mentorship of that mentor
+   * @example 500
+   */
+  @IsNotEmpty()
+  @IsNumber()
+  number_of_students: number;
+
+  /**
+   * photo url of the mentor
+   * @example 'https://g.gle/mypic.jpeg'
+   */
+  @IsNotEmpty()
+  @IsUrl()
+  mentorPhoto: string;
+
+  /**
+   * description of the mentor
+   * @example 'I am a developer'
+   */
+  @IsString()
+  aboutMe?: string;
+
+  /**
+   * Tech Stack of the mentor
+   * @example ['MERN', 'Python']
+   */
+  @IsNotEmpty()
+  @IsArray()
+  techStack: string[];
+}

--- a/src/modules/course/schema/course.schema.ts
+++ b/src/modules/course/schema/course.schema.ts
@@ -6,6 +6,7 @@ import { Review } from './review.schema';
 import { courseLevelType } from '../courseLevel.enum';
 import { Doubt } from '../../doubt/schema/doubt.schema';
 import { Assignment } from '../../assignment/schema/assignment.schema';
+import { Mentor } from 'modules/mentor/schema/mentor.schema';
 
 export type CourseDocument = Course & Document;
 
@@ -35,8 +36,8 @@ export class Course {
   @Prop({ default: 0 })
   student_num: number;
 
-  @Prop({})
-  mentor: string[];
+  @Prop({ type: [{ type: SchemaTypes.Types.ObjectId, ref: 'Mentor' }] })
+  mentor: Mentor[];
 
   @Prop({})
   video_num: number;

--- a/src/modules/user/user.controller.spec.ts
+++ b/src/modules/user/user.controller.spec.ts
@@ -25,6 +25,9 @@ describe('UserController', () => {
   const mockUservalue = {
     getAllUser: jest.fn().mockResolvedValue([mockuser]),
     getMe: jest.fn().mockResolvedValue(mockuser),
+    findUserByEmail: jest
+      .fn()
+      .mockImplementation((email) => ({ ...mockuser, email })),
     updateUser: jest.fn().mockImplementation((body) => ({
       ...mockuser,
       ...body,
@@ -75,7 +78,7 @@ describe('UserController', () => {
       await expect(controller.getAllUser()).resolves.toEqual([mockuser]);
     });
 
-    it('should be found be ID', async () => {
+    it('should be found', async () => {
       // const _id = new mongoose.Schema.Types.ObjectId('22', 0, 'rtex');
       await expect(controller.getMe()).resolves.toEqual({
         role: 'Student',
@@ -84,13 +87,32 @@ describe('UserController', () => {
       expect(service.getMe).toHaveBeenCalledWith();
     });
 
-    it('should be found be with another ID', async () => {
+    it('should be found', async () => {
       // const _id = new mongoose.Schema.Types.ObjectId('22', 0, 'rtex');
       await expect(controller.getMe()).resolves.toEqual({
         role: 'Student',
         ...mockuser,
       });
       expect(service.getMe).toHaveBeenCalledWith();
+    });
+
+    it('should be found by email ID', async () => {
+      const email = 'john@example.com';
+      await expect(controller.getuserByEmail(email)).resolves.toEqual({
+        role: 'Student',
+        ...mockuser,
+      });
+      expect(service.findUserByEmail).toHaveBeenCalledWith(email);
+    });
+
+    it('should not be found be with another email ID', async () => {
+      // const email = 'john@example.com';
+      const emailOther = 'cfc@gmail.com';
+      await expect(controller.getuserByEmail(emailOther)).resolves.not.toEqual({
+        role: 'Student',
+        ...mockuser,
+      });
+      expect(service.findUserByEmail).toHaveBeenCalledWith(emailOther);
     });
 
     it('should be updated', async () => {

--- a/src/modules/user/user.controller.spec.ts
+++ b/src/modules/user/user.controller.spec.ts
@@ -24,9 +24,7 @@ describe('UserController', () => {
 
   const mockUservalue = {
     getAllUser: jest.fn().mockResolvedValue([mockuser]),
-    getMe: jest
-      .fn()
-      .mockImplementation((_id: string) => ({ ...mockuser, _id })),
+    getMe: jest.fn().mockResolvedValue(mockuser),
     updateUser: jest.fn().mockImplementation((body) => ({
       ...mockuser,
       ...body,

--- a/src/modules/user/user.controller.spec.ts
+++ b/src/modules/user/user.controller.spec.ts
@@ -24,7 +24,7 @@ describe('UserController', () => {
 
   const mockUservalue = {
     getAllUser: jest.fn().mockResolvedValue([mockuser]),
-    findUserById: jest
+    getMe: jest
       .fn()
       .mockImplementation((_id: string) => ({ ...mockuser, _id })),
     updateUser: jest.fn().mockImplementation((body) => ({
@@ -79,20 +79,20 @@ describe('UserController', () => {
 
     it('should be found be ID', async () => {
       // const _id = new mongoose.Schema.Types.ObjectId('22', 0, 'rtex');
-      await expect(controller.getUser()).resolves.toEqual({
+      await expect(controller.getMe()).resolves.toEqual({
         role: 'Student',
         ...mockuser,
       });
-      expect(service.findUserById).toHaveBeenCalledWith();
+      expect(service.getMe).toHaveBeenCalledWith();
     });
 
     it('should be found be with another ID', async () => {
       // const _id = new mongoose.Schema.Types.ObjectId('22', 0, 'rtex');
-      await expect(controller.getUser()).resolves.toEqual({
+      await expect(controller.getMe()).resolves.toEqual({
         role: 'Student',
         ...mockuser,
       });
-      expect(service.findUserById).toHaveBeenCalledWith();
+      expect(service.getMe).toHaveBeenCalledWith();
     });
 
     it('should be updated', async () => {


### PR DESCRIPTION
Fix failing tests 

1).Earlier the tests were failing after findById function was renamed as getMe in service
Now testing file has been refactored accordingly and has been fixed

2).Refactored getMe in user.controller tests specfile. 

3).Also populated doubts and doubtAnswers using deep populate in get single course by Id endpoint

4). Added tests for get by email ID controller

5). Added an endpoint to add mentor to a course
and populates it in the course cards and get individual endpoints.

![image](https://user-images.githubusercontent.com/59202075/128639001-b7fadadd-e00b-4ef2-9f07-54acdb8835a4.png)


How Has This Been Tested?

Terminal commands to test code:-
1). npm run lint
2). npm run lint:fix
3). nest start
4). npm run test