### PR TITLE
Adding pagination and enrolled course duplicacy fix

### DIFF
--- a/src/modules/course/course.controller.spec.ts
+++ b/src/modules/course/course.controller.spec.ts
@@ -79,7 +79,9 @@ describe('CourseController', () => {
   describe('Course', () => {
     // course creation
     it('should be created', async () => {
-      await expect(controller.getAllCourses()).resolves.toEqual([mockCourse]);
+      await expect(controller.getAllCourses('0')).resolves.toEqual([
+        mockCourse,
+      ]);
     });
 
     // course found by id

--- a/src/modules/course/course.controller.ts
+++ b/src/modules/course/course.controller.ts
@@ -44,8 +44,8 @@ export class CourseController {
     summary: 'get brief information on cards for all courses initially',
   })
   @ApiOkResponse(responsedoc.getAllCourses)
-  async getBreifAllCourses() {
-    return await this.courseService.getBreifAllCourses();
+  async getBreifAllCourses(@Query('skipNum') skipNum: string) {
+    return await this.courseService.getBreifAllCourses(skipNum);
   }
 
   @Get('/all/query')
@@ -58,8 +58,8 @@ export class CourseController {
   @Get('/all')
   @ApiOperation({ summary: 'get all courses' })
   @ApiOkResponse(responsedoc.getAllCourses)
-  async getAllCourses() {
-    return await this.courseService.getAllCourses();
+  async getAllCourses(@Query('skipNum') skipNum: string) {
+    return await this.courseService.getAllCourses(skipNum);
   }
 
   @Get('/:courseId')

--- a/src/modules/course/course.service.ts
+++ b/src/modules/course/course.service.ts
@@ -50,9 +50,10 @@ export class CourseService {
   }
 
   // fetch all courses
-  async getAllCourses(): Promise<Course[]> {
+  async getAllCourses(skipNum: string): Promise<Course[]> {
     try {
-      return await this.CourseModel.find()
+      const skip = parseInt(skipNum, 10);
+      return await this.CourseModel.find({}, {}, { skip: skip, limit: 10 })
         .populate('schedule')
         .populate('reviews')
         .populate('assignments')
@@ -63,9 +64,10 @@ export class CourseService {
   }
 
   // fetch brief info for cards for all courses
-  async getBreifAllCourses(): Promise<Course[]> {
+  async getBreifAllCourses(skipNum: string): Promise<Course[]> {
     try {
-      return await this.CourseModel.find()
+      const skip = parseInt(skipNum, 10);
+      return await this.CourseModel.find({}, {}, { skip: skip, limit: 10 })
         .select(
           'name courseShortDescription tags rating no_of_enrollments mentor crossPrice courseLevel courseThumbnail duration reviews video_num isUpcoming',
         )

--- a/src/modules/course/schema/enrolledCourse.schema.ts
+++ b/src/modules/course/schema/enrolledCourse.schema.ts
@@ -26,9 +26,6 @@ export class EnrolledCourse {
   @Prop()
   currentVideo: video[];
 
-  @Prop()
-  doubts: string[];
-
   @Prop({ required: true })
   courseId: SchemaType.Types.ObjectId;
 }

--- a/src/modules/doubt/doubt.controller.ts
+++ b/src/modules/doubt/doubt.controller.ts
@@ -6,6 +6,7 @@ import {
   Param,
   Post,
   Put,
+  Query,
 } from '@nestjs/common';
 import {
   ApiCreatedResponse,
@@ -33,8 +34,8 @@ export class DoubtController {
   @Get()
   @ApiOkResponse(responsedoc.getAllDoubts)
   @ApiOperation({ summary: 'Retrieve doubts list' })
-  async getAllDoubts() {
-    return await this.doubtService.getAllDoubts();
+  async getAllDoubts(@Query('skipNum') skipNum: string) {
+    return await this.doubtService.getAllDoubts(skipNum);
   }
 
   @Get('/get/:doubtId')

--- a/src/modules/doubt/doubt.service.ts
+++ b/src/modules/doubt/doubt.service.ts
@@ -30,9 +30,16 @@ export class DoubtService {
   ) {}
 
   // fetch all Doubts
-  async getAllDoubts() {
+  async getAllDoubts(skipNum: string) {
     try {
-      const doubts = await this.DoubtModel.find().populate('answers').lean();
+      const skip = parseInt(skipNum, 10);
+      const doubts = await this.DoubtModel.find(
+        {},
+        {},
+        { skip: skip, limit: 10 },
+      )
+        .populate('answers')
+        .lean();
       return doubts;
     } catch (e) {
       throw new InternalServerErrorException(e);

--- a/src/modules/doubt/doubt.service.ts
+++ b/src/modules/doubt/doubt.service.ts
@@ -76,7 +76,6 @@ export class DoubtService {
         const doubtToBeCreated = {
           ...createDoubtDto,
           photoUrl: user.photoUrl,
-          askedBy_name: user.first_name,
         };
         const newDoubt = await new this.DoubtModel(doubtToBeCreated).save();
         course.doubts.push(newDoubt);
@@ -167,7 +166,6 @@ export class DoubtService {
         const doubtAnswerToBeCreated = {
           ...createDoubtAnswerDto,
           photoUrl: user.photoUrl,
-          answeredBy_name: user.first_name,
         };
         const newDoubtAnswer = await new this.DoubtAnswerModel(
           doubtAnswerToBeCreated,

--- a/src/modules/doubt/dto/create-doubt.dto.ts
+++ b/src/modules/doubt/dto/create-doubt.dto.ts
@@ -22,7 +22,7 @@ export class CreateDoubtDto {
   tags?: TagType[];
 
   /**
-   * The name of the person who asked the doubt
+   * The id of the person who asked the doubt
    * @example '60ccf3037025096f45cb87bf'
    */
   @IsNotEmpty()
@@ -63,4 +63,12 @@ export class CreateDoubtDto {
    */
   @IsString()
   doubtBody?: string;
+
+  /**
+   * The person who aasked the doubt
+   * @example "John Doe"
+   */
+  @IsString()
+  @IsNotEmpty()
+  askedBy_name: string;
 }

--- a/src/modules/doubt/dto/create-doubtAnswer.dto.ts
+++ b/src/modules/doubt/dto/create-doubtAnswer.dto.ts
@@ -4,7 +4,7 @@ import { Schema } from 'mongoose';
 
 export class CreateDoubtAnswerDto {
   /**
-   * The name of the person who answered the doubt
+   * The id of the person who answered the doubt
    * @example '60ccf3037025096f45cb87bf'
    */
   @IsNotEmpty()
@@ -14,10 +14,18 @@ export class CreateDoubtAnswerDto {
   answered_by: Schema.Types.ObjectId;
 
   /**
-   * The asnwer to the doubt
+   * The anwwer to the doubt
    * @example "We use this to conserve time by applying alogorithm of lesser time complexity"
    */
   @IsString()
   @IsNotEmpty()
   answer: string;
+
+  /**
+   * The person who answered the doubt
+   * @example "John Doe"
+   */
+  @IsString()
+  @IsNotEmpty()
+  answeredBy_name: string;
 }

--- a/src/modules/user/dto/create-enrolled.dto.ts
+++ b/src/modules/user/dto/create-enrolled.dto.ts
@@ -31,12 +31,6 @@ export class CreateEnrolledDTO {
    */
   currentVideo: video[];
 
-  /**
-   * The doubts of the student
-   * @example ['problem in BFS', 'unable to understand Dynamic Programming']
-   */
-  doubts: string[];
-
   @IsNotEmpty()
   @IsMongoId()
   @ApiProperty({ type: Schema.Types.ObjectId })

--- a/src/modules/user/dto/update-enrolled.dto.ts
+++ b/src/modules/user/dto/update-enrolled.dto.ts
@@ -21,10 +21,4 @@ export class UpdateEnrolledDTO {
    * @example { num: 1, timestamp: Date.now() }
    */
   currentVideo: video[];
-
-  /**
-   * The doubts of the student
-   * @example ['problem in BFS', 'unable to understand Dynamic Programming']
-   */
-  doubts: string[];
 }


### PR DESCRIPTION
Adding pagination with skipNum parameter of mongodb in course ,cards and doubts

As we see below, the query parameter skipNum will tell us how many documents to skip and the limit for the number of documents returned via each pipeline is set to 10 documents

![image](https://user-images.githubusercontent.com/59202075/129362423-c268d964-3360-41de-80d4-9e5eaa911aa7.png)

-x- Fixed enrolled course duplicacy and gave appropriate error for any duplicacy
-x- Refactored some schemas in dtos and deleted unused fields 
-x- Added askedyBy_name and answeredBy_name in create doubts and doubtAnswer dto for localstorage implementation and correct workflow

**Type of Change:**

- [x] Code
- [x] New Feature
- [x] Documentation


**How Has This Been Tested?**

Terminal commands to test code:-
1). npm run lint
2). npm run lint:fix
3). nest start
4). npm run test

**Checklist**

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] My changes generate no new warnings
- [x] The title of my pull request is a short description of the requested changes.
