### PR TITLE
Endpoint to get gamification board data

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -52,6 +52,10 @@ export class AppModule {
           method: RequestMethod.GET,
         },
         {
+          path: 'user/Gamification',
+          method: RequestMethod.GET,
+        },
+        {
           path: 'Doubt/(.*)',
           method: RequestMethod.GET,
         },

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -52,7 +52,7 @@ export class AppModule {
           method: RequestMethod.GET,
         },
         {
-          path: 'user/Gamification',
+          path: 'user/gamification',
           method: RequestMethod.GET,
         },
         {

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -15,7 +15,7 @@ import { APP_GUARD } from '@nestjs/core';
 import * as dotenv from 'dotenv';
 import { PreauthMiddleware } from './middleware/preAuth.middleware';
 import { RolesGuard } from './middleware/roles.guard';
-import { UserSchema } from './modules/user/schema/user.schema';
+import UserSchema from './modules/user/schema/user.schema';
 dotenv.config({ path: path.resolve(__dirname, '..', '.env') });
 
 @Module({

--- a/src/middleware/preAuth.middleware.ts
+++ b/src/middleware/preAuth.middleware.ts
@@ -26,12 +26,19 @@ export class PreauthMiddleware implements NestMiddleware {
 
           if (userExists) {
             role = userExists.role || Role.STUDENT;
+            await this.userModel.updateOne(
+              { email: userExists.email },
+              {
+                log_in_time: new Date().toString(),
+              },
+            );
           } else {
             const newUser = new this.userModel({
               email,
               fid: uid,
               role: Role.STUDENT,
               photoUrl: picture,
+              log_in_time: ' ',
             });
             await newUser.save();
             role = Role.STUDENT;

--- a/src/modules/doubt/doubt.module.ts
+++ b/src/modules/doubt/doubt.module.ts
@@ -5,7 +5,7 @@ import { DoubtController } from './doubt.controller';
 import { DoubtService } from './doubt.service';
 import { CourseSchema } from '../course/schema/course.schema';
 import { DoubtAnswerSchema } from './schema/doubtAnswer.schema';
-import { UserSchema } from '../user/schema/user.schema';
+import UserSchema from '../user/schema/user.schema';
 
 @Module({
   imports: [

--- a/src/modules/user/docUtils/apidoc.ts
+++ b/src/modules/user/docUtils/apidoc.ts
@@ -1,5 +1,6 @@
 import UserResponseBody, {
   EnrolledCourseResponseBody,
+  getAllGamifiedResponseBody,
 } from './user.responsedoc';
 import { ApiResponseOptions } from '@nestjs/swagger';
 
@@ -64,6 +65,11 @@ const deleteCartList: ApiResponseOptions = {
   type: UserResponseBody,
 };
 
+const getAllGamified: ApiResponseOptions = {
+  description: 'Delete course from cartList',
+  type: getAllGamifiedResponseBody,
+};
+
 const responses = {
   addUser,
   getAllUser,
@@ -77,6 +83,7 @@ const responses = {
   addCartList,
   deleteCartList,
   getCartList,
+  getAllGamified,
 };
 
 export default responses;

--- a/src/modules/user/docUtils/user.responsedoc.ts
+++ b/src/modules/user/docUtils/user.responsedoc.ts
@@ -155,7 +155,7 @@ export class getAllGamifiedResponseBody {
 
   /**
    * The photo url
-   * @example 'https://g.gle/mypic.jpeg'
+   * @example 'https://cdn.pixabay.com/photo/2015/03/04/22/35/head-659652_1280.png'
    */
   photoUrl: string;
 }

--- a/src/modules/user/docUtils/user.responsedoc.ts
+++ b/src/modules/user/docUtils/user.responsedoc.ts
@@ -83,6 +83,12 @@ export default class UserResponseBody {
    * @example "60ccf3037025096f45cb87ba"
    */
   fId: string;
+
+  /**
+   * Login Time
+   * @example "Wed Aug 18 2021 00:13:13 GMT+0530 (India Standard Time)"
+   */
+  log_in_time: string;
 }
 
 interface video {

--- a/src/modules/user/docUtils/user.responsedoc.ts
+++ b/src/modules/user/docUtils/user.responsedoc.ts
@@ -41,6 +41,10 @@ export default class UserResponseBody {
    */
   description: string;
 
+  /**
+   * Score of the user
+   * @example 100
+   */
   score: number;
 
   /**
@@ -122,4 +126,30 @@ export class EnrolledCourseResponseBody {
    * @example "60ccf06ad682336931f0a61b"
    */
   courseId: string;
+}
+
+export class getAllGamifiedResponseBody {
+  /**
+   * First name of the user
+   * @example 'John'
+   */
+  first_name: string;
+
+  /**
+   * Last name of the user
+   * @example 'Doe'
+   */
+  last_name: string;
+
+  /**
+   * Score of the user
+   * @example 100
+   */
+  score: number;
+
+  /**
+   * The photo url
+   * @example 'https://g.gle/mypic.jpeg'
+   */
+  photoUrl: string;
 }

--- a/src/modules/user/schema/user.schema.ts
+++ b/src/modules/user/schema/user.schema.ts
@@ -46,7 +46,10 @@ export class User {
   fId: string;
 }
 
-export const UserSchema = SchemaFactory.createForClass(User);
+const UserSchema = SchemaFactory.createForClass(User);
+
+UserSchema.index({ score: 1 });
+export default UserSchema;
 
 UserSchema.methods.toJSON = function () {
   const userObject = this.toObject();

--- a/src/modules/user/schema/user.schema.ts
+++ b/src/modules/user/schema/user.schema.ts
@@ -44,6 +44,9 @@ export class User {
 
   @Prop()
   fId: string;
+
+  @Prop()
+  log_in_time: string;
 }
 
 const UserSchema = SchemaFactory.createForClass(User);

--- a/src/modules/user/user.controller.spec.ts
+++ b/src/modules/user/user.controller.spec.ts
@@ -16,6 +16,7 @@ const mockuser = {
   phone: '9909999099',
   __v: 0,
   photoUrl: 'https://google.com/john',
+  log_in_time: 'Wed Aug 18 2021 00:13:13 GMT+0530 (India Standard Time)',
 };
 
 describe('UserController', () => {
@@ -70,6 +71,7 @@ describe('UserController', () => {
       await expect(controller.addUser('x', dto)).resolves.toEqual({
         '0': 'x',
         role: 'Student',
+        log_in_time: 'Wed Aug 18 2021 00:13:13 GMT+0530 (India Standard Time)',
         ...mockuser,
       });
     });
@@ -133,6 +135,7 @@ describe('UserController', () => {
         email,
         role: 'Student',
         ...dto,
+        log_in_time: 'Wed Aug 18 2021 00:13:13 GMT+0530 (India Standard Time)',
         cartList: [],
         wishlist: [],
         enrolled_courses: [],

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -131,8 +131,8 @@ export class UserController {
   @Get('/gamification')
   @ApiOperation({ summary: 'Gamification data retreival endpoint' })
   @ApiOkResponse(responsedoc.getAllGamified)
-  async getAllGamified() {
-    return await this.userService.getAllGamified();
+  async getAllGamified(@Query('skipNum') skipNum: string) {
+    return await this.userService.getAllGamified(skipNum);
   }
 
   @Put('/update')

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -131,8 +131,8 @@ export class UserController {
   @Get('/gamification')
   @ApiOperation({ summary: 'Gamification data retreival endpoint' })
   @ApiOkResponse(responsedoc.getAllGamified)
-  async getAllGamified(@Query('skipNum') skipNum: string) {
-    return await this.userService.getAllGamified(skipNum);
+  async getAllGamified(@Query('skip') skip: string) {
+    return await this.userService.getAllGamified(skip);
   }
 
   @Put('/update')

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -121,10 +121,18 @@ export class UserController {
   }
 
   @Get('/users')
+  @Roles(Role.ADMIN)
   @ApiOperation({ summary: 'Retreive user list' })
   @ApiOkResponse(responsedoc.getAllUser)
   async getAllUser() {
     return await this.userService.getAllUser();
+  }
+
+  @Get('/Gamification')
+  @ApiOperation({ summary: 'Gamification data retreival endpoint' })
+  @ApiOkResponse(responsedoc.getAllGamified)
+  async getAllGamified() {
+    return await this.userService.getAllGamified();
   }
 
   @Put('/update')

--- a/src/modules/user/user.controller.ts
+++ b/src/modules/user/user.controller.ts
@@ -128,7 +128,7 @@ export class UserController {
     return await this.userService.getAllUser();
   }
 
-  @Get('/Gamification')
+  @Get('/gamification')
   @ApiOperation({ summary: 'Gamification data retreival endpoint' })
   @ApiOkResponse(responsedoc.getAllGamified)
   async getAllGamified() {

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common';
 import { UserController } from './user.controller';
 import { UserService } from './user.service';
 import { MongooseModule } from '@nestjs/mongoose';
-import { UserSchema } from './schema/user.schema';
+import UserSchema from './schema/user.schema';
 import { CourseSchema } from '../course/schema/course.schema';
 import { EnrolledCourseSchema } from '../course/schema/enrolledCourse.schema';
 @Module({

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -38,10 +38,11 @@ export class UserService {
   }
 
   // fetch all gamification data
-  async getAllGamified(): Promise<User[]> {
+  async getAllGamified(skipNum: string): Promise<User[]> {
     try {
+      const skip = parseInt(skipNum, 10);
       const users = await this.userModel
-        .find({}, { _id: false })
+        .find({}, { _id: false }, { skip: skip, limit: 10 })
         .select('first_name last_name score photoUrl')
         .sort({ score: 1 })
         .exec();

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -38,13 +38,13 @@ export class UserService {
   }
 
   // fetch all gamification data
-  async getAllGamified(skipNum: string): Promise<User[]> {
+  async getAllGamified(skip: string): Promise<User[]> {
     try {
-      const skip = parseInt(skipNum, 10);
+      const skipNum = parseInt(skip, 10);
       const users = await this.userModel
-        .find({}, { _id: false }, { skip: skip, limit: 10 })
+        .find({}, { _id: false }, { skip: skipNum, limit: 10 })
         .select('first_name last_name score photoUrl')
-        .sort({ score: 1 })
+        .sort({ score: -1 })
         .exec();
       return users;
     } catch (e) {

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -43,6 +43,7 @@ export class UserService {
       const users = await this.userModel
         .find({}, { _id: false })
         .select('first_name last_name score photoUrl')
+        .sort({ score: 1 })
         .exec();
       return users;
     } catch (e) {

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -37,6 +37,19 @@ export class UserService {
     }
   }
 
+  // fetch all gamification data
+  async getAllGamified(): Promise<User[]> {
+    try {
+      const users = await this.userModel
+        .find({}, { _id: false })
+        .select('first_name last_name score photoUrl')
+        .exec();
+      return users;
+    } catch (e) {
+      throw new InternalServerErrorException(e);
+    }
+  }
+
   // Get a single User
   async findUserByEmail(query): Promise<User> {
     try {


### PR DESCRIPTION
**Description**

Add endpoint to retrieve gamification data
Data for gamification boards will be retrieved
Suitable endpoint and documentation has been added
Added index and ordering for the request of gamification data

Used the below link as reference for indexing collection based on a feild
https://docs.mongodb.com/manual/tutorial/sort-results-with-indexes/



![image](https://user-images.githubusercontent.com/59202075/129767612-e7d3dc90-d26d-4e94-ae7e-928b1c819ce1.png)

![image](https://user-images.githubusercontent.com/59202075/130010373-14d730a3-cbca-4559-ba06-f7515619a076.png)



**Type of Change:**

- [x] Code
- [x] New Feature
- [x] Documentation


**How Has This Been Tested?**

Terminal commands to test code:-
1). npm run lint
2). npm run lint:fix
3). nest start
4). npm run test

**Checklist**

- [x] My code follows the code style of this project.
- [x] I have updated the documentation accordingly.
- [x] All new and existing tests passed.
- [x] My changes generate no new warnings
- [x] The title of my pull request is a short description of the requested changes.